### PR TITLE
219 - updates packages version `opencv-contrib-python-headless>=4.2.0.32` and `PySide6>=6.5.1.1`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # which are listed in requirements-dev.rst and requirements-docs.rst
 numpy>=1.11
 vtk>=9.2.6
-PySide6>=6.5.0
-opencv-contrib-python-headless>=4.7.0.72
+PySide6>=6.5.1.1
+opencv-contrib-python-headless>=4.2.0.32
 scikit-surgerycore>=0.1.7
 scikit-surgeryimage>=0.10.1

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
     install_requires=[
         'numpy>=1.11',
         'vtk>=9.2.6',
-        'PySide6>=6.5.0',
-        'opencv-contrib-python-headless>=4.7.0.72',
+        'PySide6>=6.5.1.1',
+        'opencv-contrib-python-headless>=4.2.0.32',
         'scikit-surgerycore>=0.1.7',
         'scikit-surgeryimage>=0.10.1',
     ],


### PR DESCRIPTION
# Resolving #219 

Hi @thompson318 

I have updated packages version of `opencv-contrib-python-headless>=4.2.0.32` and `PySide6>=6.5.1.1` and unit tests look good to me: 
*  local unit tests
```
  py38: OK (57.50=setup[0.04]+cmd[0.11,57.10,0.25] seconds)
  lint: OK (15.00=setup[0.02]+cmd[14.99] seconds)
  congratulations :) (72.62 seconds)
```
* remote unit tests : https://github.com/SciKit-Surgery/scikit-surgeryvtk/actions/runs/5314435124

Let me know if you have any comments, otherwise, this PR should be ready to be merged to then proceed with a new release version `2.0.1`

Cheers, --Miguel